### PR TITLE
update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         fi
         chmod +x ./gradlew
         ./gradlew assembleRelease
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: Package
         path: app/build/outputs/apk


### PR DESCRIPTION
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/